### PR TITLE
feat: create prod environment folder

### DIFF
--- a/infra/env/prod/backend.tfvars
+++ b/infra/env/prod/backend.tfvars
@@ -1,0 +1,4 @@
+bucket         = "terraform-state-637423468901"
+key            = "state/tfstate"
+region         = "eu-west-1"
+dynamodb_table = "terraform-lock"

--- a/infra/env/prod/terraform.tfvars
+++ b/infra/env/prod/terraform.tfvars
@@ -1,0 +1,8 @@
+tags = {
+  "CreatedBy"   = "Terraform"
+  "Environment" = "Prod"
+  "Owner"       = "Subdomaintakeover"
+  "Scope"       = "tfstate"
+  "Source"      = "https://github.com/pagopa/subdomain-takeover-monitoring"
+  "name"        = "S3 Remote Terraform State Store"
+}

--- a/infra/init/setup-terraform-backend.sh
+++ b/infra/init/setup-terraform-backend.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export AWS_PROFILE=$1
-REGION="eu-south-1"
+REGION="eu-west-1"
 RANDOM_STRING=$(date +%s)
 S3_BUCKET_NAME="terraform-state-${RANDOM_STRING}"
 DYNAMO_TABLE_NAME="terraform-lock"


### PR DESCRIPTION
This PR creates a production environment in a different region (eu-west-1) for subdomain-takoever-monitoring-tool. 

Run `./terraform.sh apply prod` after the PR has been merged to create the environment on the cloud. 