### PR TITLE
Fix: health check subdomain takeover monitoring tool aws

### DIFF
--- a/.github/workflows/health-check-dev.yml
+++ b/.github/workflows/health-check-dev.yml
@@ -1,0 +1,54 @@
+name: Subdomain takeover monitoring tool health check on AWS dev env
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC
+jobs:
+  setup:
+    name: Setup environment
+    runs-on: ubuntu-24.04
+    environment: dev
+    env:
+      DEPLOY_ENV: dev
+    permissions:
+      id-token: write   # This is required for requesting the OIDC JWT
+      contents: read    # This is required for actions/checkout Action
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0
+        with:
+          aws-region: eu-south-1
+          role-to-assume: ${{ secrets.ARN_ROLE }}
+          role-session-name: oidc-gha-assume-role-session
+      - name: Make scripts executable
+        id: make-scripts-executable
+        run: chmod +x scripts/aws/*.sh
+      - name: Generate random DNS ZoneId and ZoneName
+        id: generate-variables
+        run: ./scripts/aws/generate_variables.sh
+        shell: bash
+      - name: Create DNS Zone Route53
+        id: create-dns-zone
+        run: ./scripts/aws/create_dns_zone.sh
+      - name: Create bucket S3
+        id: create-bucket-s3
+        run: ./scripts/aws/create_bucket_s3.sh
+      - name: Create CNAME record for S3
+        id: create-cname-record-for-s3
+        run: ./scripts/aws/create_cname_record_for_s3.sh
+      - name: Delete S3 bucket
+        id: delete-s3-bucket
+        run: ./scripts/aws/delete_s3_bucket.sh
+      - name: Invoke lambda and send alert to Slack
+        id: invoke-lambda-aws-subdomain-tool
+        run: ./scripts/aws/invoke_lambda.sh 
+      - name: Delete DNS zone and cleanup records
+        id: delete-dns-zone
+        run: ./scripts/aws/delete_dns_zone.sh
+      - name: Invalidate OIDC Token
+        id: invalidate-oidc-token
+        run: |
+          aws sso logout

--- a/.github/workflows/health-check-dev.yml
+++ b/.github/workflows/health-check-dev.yml
@@ -15,7 +15,6 @@ jobs:
     environment: dev
     env:
       DEPLOY_ENV: dev
-      REGION: ${{ vars.REGION }}
     permissions:
       id-token: write   # This is required for requesting the OIDC JWT
       contents: read    # This is required for actions/checkout Action

--- a/.github/workflows/health-check-dev.yml
+++ b/.github/workflows/health-check-dev.yml
@@ -1,6 +1,7 @@
 name: Subdomain takeover monitoring tool health check on AWS dev env
 
 on:
+  push:
   workflow_dispatch:
   schedule:
     - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC

--- a/.github/workflows/health-check-dev.yml
+++ b/.github/workflows/health-check-dev.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-  push:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC
 jobs:
   setup:
     name: Setup environment

--- a/.github/workflows/health-check-dev.yml
+++ b/.github/workflows/health-check-dev.yml
@@ -1,6 +1,9 @@
-name: Subdomain takeover monitoring tool health check on AWS dev env
+name: Subdomain takeover monitoring tool health check on AWS develop environment
 
 on:
+  pull_request:
+    branches:
+      - develop
   push:
   workflow_dispatch:
   schedule:
@@ -12,6 +15,7 @@ jobs:
     environment: dev
     env:
       DEPLOY_ENV: dev
+      REGION: ${{ vars.REGION }}
     permissions:
       id-token: write   # This is required for requesting the OIDC JWT
       contents: read    # This is required for actions/checkout Action
@@ -21,7 +25,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0
         with:
-          aws-region: eu-south-1
+          aws-region: ${{ vars.REGION }}
           role-to-assume: ${{ secrets.ARN_ROLE }}
           role-session-name: oidc-gha-assume-role-session
       - name: Make scripts executable

--- a/.github/workflows/health-check-dev.yml
+++ b/.github/workflows/health-check-dev.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+  workflow_dispatch:
 jobs:
   setup:
     name: Setup environment

--- a/.github/workflows/health-check-prod.yml
+++ b/.github/workflows/health-check-prod.yml
@@ -1,14 +1,16 @@
-name: Subdomain takeover monitoring tool health check on AWS
+name: Subdomain takeover monitoring tool health check on AWS production environment
 
 on:
-  workflow_dispatch:
+  #workflow_dispatch:
   schedule:
     - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC
 jobs:
   setup:
     name: Setup environment
     runs-on: ubuntu-24.04
-    environment: dev
+    environment: prod
+    env:
+      DEPLOY_ENV: prod
     permissions:
       id-token: write   # This is required for requesting the OIDC JWT
       contents: read    # This is required for actions/checkout Action
@@ -18,7 +20,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0
         with:
-          aws-region: eu-south-1
+          aws-region: eu-west-1
           role-to-assume: ${{ secrets.ARN_ROLE }}
           role-session-name: oidc-gha-assume-role-session
       - name: Make scripts executable
@@ -40,9 +42,19 @@ jobs:
       - name: Delete S3 bucket
         id: delete-s3-bucket
         run: ./scripts/aws/delete_s3_bucket.sh
+      - name: Change slack channel to dev
+        id: change-slack-channel-to-dev
+        run: ./scripts/aws/change_slack_channel_to_dev.sh
+        env: 
+          DEV_ENV_VALUE: ${{ secrets.DEV_ENV_VALUE }}
       - name: Invoke lambda and send alert to Slack
         id: invoke-lambda-aws-subdomain-tool
         run: ./scripts/aws/invoke_lambda.sh
+      - name: Change slack channel to prod
+        id: change-slack-channel-to-prod
+        run: ./scripts/aws/change_slack_channel_to_prod.sh
+        env: 
+          PROD_ENV_VALUE: ${{ secrets.PROD_ENV_VALUE }}
       - name: Delete DNS zone and cleanup records
         id: delete-dns-zone
         run: ./scripts/aws/delete_dns_zone.sh

--- a/.github/workflows/health-check-prod.yml
+++ b/.github/workflows/health-check-prod.yml
@@ -7,7 +7,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC
+    - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC 
 jobs:
   setup:
     name: Setup environment

--- a/.github/workflows/health-check-prod.yml
+++ b/.github/workflows/health-check-prod.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC 

--- a/.github/workflows/health-check-prod.yml
+++ b/.github/workflows/health-check-prod.yml
@@ -7,7 +7,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC 
+    - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC
 jobs:
   setup:
     name: Setup environment

--- a/.github/workflows/health-check-prod.yml
+++ b/.github/workflows/health-check-prod.yml
@@ -1,7 +1,11 @@
 name: Subdomain takeover monitoring tool health check on AWS production environment
 
 on:
-  #workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+  workflow_dispatch:
   schedule:
     - cron: '0 7 * * 2' #Every tuesday at 7:00 UTC
 jobs:
@@ -20,7 +24,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0
         with:
-          aws-region: eu-west-1
+          aws-region: ${{ vars.REGION }}
           role-to-assume: ${{ secrets.ARN_ROLE }}
           role-session-name: oidc-gha-assume-role-session
       - name: Make scripts executable

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,8 +1,8 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_iam_role" "github_health_check_role" {
-  name        = "SubdomainTakeoverHealthCheckRole"
-  description = "Role to perform healt check of subdomain takeover monitoring tool"
+  name        = "SubdomainTakeoverHealthCheckRole-${var.env}"
+  description = "Role to perform healt check of subdomain takeover monitoring tool in ${var.env} environment"
 
 
   assume_role_policy = jsonencode({
@@ -31,12 +31,13 @@ resource "aws_iam_role" "github_health_check_role" {
 }
 
 resource "aws_iam_policy" "subdomain_health_check_policy" {
-  name        = "SubdomainHealtCheckPolicy"
-  description = "Policy to perform healt check of subdomain takeover monitoring tool"
+  name        = "SubdomainHealtCheckPolicy-${var.env}"
+  description = "Policy to perform healt check of subdomain takeover monitoring tool in ${var.env} environment"
 
-  policy = file(
-    "./iam_policies/health-check-policy.json"
-  )
+  policy = templatefile("iam_policies/health-check-policy.json.tmpl", {
+    region             = var.aws_region
+    env                = var.env
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "subdomain_health_check" {

--- a/infra/iam_policies/health-check-policy.json.tmpl
+++ b/infra/iam_policies/health-check-policy.json.tmpl
@@ -36,7 +36,7 @@
         "lambda:GetFunctionConfiguration",
         "lambda:UpdateFunctionConfiguration"
       ],
-      "Resource": "arn:aws:lambda:eu-south-1:637423468901:function:aws_verify-takeover-dev"
+      "Resource": "arn:aws:lambda:${region}:637423468901:function:aws_verify-takeover-${env}"
     },
     {
       "Sid": "LambdaInvoke",
@@ -44,7 +44,7 @@
       "Action": [
         "lambda:InvokeFunction"
       ],
-      "Resource": "arn:aws:lambda:eu-south-1:637423468901:function:aws_list-accounts-dev"
+      "Resource": "arn:aws:lambda:${region}:637423468901:function:aws_list-accounts-${env}"
     }
   ]
 }

--- a/infra/init/setup-terraform-backend.sh
+++ b/infra/init/setup-terraform-backend.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export AWS_PROFILE=$1
-REGION="eu-west-1"
+REGION=""
 RANDOM_STRING=$(date +%s)
 S3_BUCKET_NAME="terraform-state-${RANDOM_STRING}"
 DYNAMO_TABLE_NAME="terraform-lock"

--- a/scripts/aws/change_slack_channel_to_dev.sh
+++ b/scripts/aws/change_slack_channel_to_dev.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "🔗 Changing slack channel id to dev..."
-LAMBDA_NAME="aws_verify-takeover-dev"
+LAMBDA_NAME="aws_verify-takeover-$DEPLOY_ENV"
 CURRENT_ENV=$(aws lambda get-function-configuration --function-name "$LAMBDA_NAME" --query 'Environment.Variables' --output json)
 ENV_KEY="CHANNEL_ID"
 UPDATED_ENV=$(echo "$CURRENT_ENV" | jq --arg key "$ENV_KEY" --arg value "$DEV_ENV_VALUE" '.[$key] = $value')

--- a/scripts/aws/change_slack_channel_to_prod.sh
+++ b/scripts/aws/change_slack_channel_to_prod.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "🔗 Changing slack channel id to prod..."
-LAMBDA_NAME="aws_verify-takeover-dev"
+LAMBDA_NAME="aws_verify-takeover-$DEPLOY_ENV"
 CURRENT_ENV=$(aws lambda get-function-configuration --function-name "$LAMBDA_NAME" --query 'Environment.Variables' --output json)
 ENV_KEY="CHANNEL_ID"
 UPDATED_ENV=$(echo "$CURRENT_ENV" | jq --arg key "$ENV_KEY" --arg value "$PROD_ENV_VALUE" '.[$key] = $value')

--- a/scripts/aws/change_slack_channel_to_prod.sh
+++ b/scripts/aws/change_slack_channel_to_prod.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-echo "🔗 Changing slack channel id to prod"
+echo "🔗 Changing slack channel id to prod..."
 LAMBDA_NAME="aws_verify-takeover-dev"
 CURRENT_ENV=$(aws lambda get-function-configuration --function-name "$LAMBDA_NAME" --query 'Environment.Variables' --output json)
 ENV_KEY="CHANNEL_ID"

--- a/scripts/aws/create_bucket_s3.sh
+++ b/scripts/aws/create_bucket_s3.sh
@@ -2,7 +2,6 @@
 set -e
 
 echo "🔗 Creating S3 bucket..."
-REGION="eu-south-1"
 echo "$subdomain_and_s3_name"
 aws s3api create-bucket --bucket $subdomain_and_s3_name --region $REGION --create-bucket-configuration LocationConstraint=$REGION
 aws s3api put-public-access-block --bucket $subdomain_and_s3_name --public-access-block-configuration "{\"BlockPublicAcls\": false, \"IgnorePublicAcls\": false, \"BlockPublicPolicy\": false, \"RestrictPublicBuckets\": false}"

--- a/scripts/aws/create_bucket_s3.sh
+++ b/scripts/aws/create_bucket_s3.sh
@@ -3,10 +3,10 @@ set -e
 
 echo "🔗 Creating S3 bucket..."
 echo "$subdomain_and_s3_name"
-aws s3api create-bucket --bucket $subdomain_and_s3_name --region $REGION --create-bucket-configuration LocationConstraint=$REGION
+aws s3api create-bucket --bucket $subdomain_and_s3_name --region $AWS_REGION --create-bucket-configuration LocationConstraint=$AWS_REGION
 aws s3api put-public-access-block --bucket $subdomain_and_s3_name --public-access-block-configuration "{\"BlockPublicAcls\": false, \"IgnorePublicAcls\": false, \"BlockPublicPolicy\": false, \"RestrictPublicBuckets\": false}"
 aws s3api put-bucket-ownership-controls --bucket $subdomain_and_s3_name --ownership-controls '{ "Rules": [ { "ObjectOwnership": "BucketOwnerPreferred" } ] }'
 aws s3api put-bucket-acl --bucket $subdomain_and_s3_name --acl public-read-write
-S3_FQDN="$subdomain_and_s3_name.s3.$REGION.amazonaws.com"
+S3_FQDN="$subdomain_and_s3_name.s3.$AWS_REGION.amazonaws.com"
 echo "bucket_url=https://$S3_FQDN" >> $GITHUB_ENV
 echo "✅ S3 bucket created correctly."

--- a/scripts/aws/delete_dns_zone.sh
+++ b/scripts/aws/delete_dns_zone.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -e
 
-echo "🧹 Cleaning up DNS zone... but before waiting for 3 minutes"
-sleep 180
+echo "🧹 Cleaning up DNS zone..."
 RECORDS=$(aws route53 list-resource-record-sets \
   --hosted-zone-id $zone_id \
   --query "ResourceRecordSets[?Type!='NS' && Type!='SOA']" \

--- a/scripts/aws/invoke_lambda.sh
+++ b/scripts/aws/invoke_lambda.sh
@@ -2,9 +2,11 @@
 set -e
 
 echo "🔗 Invoking lambda of subdomain takeover monitoring tool for AWS..."
-LAMBDA_NAME="aws_list-accounts-dev"
+LAMBDA_NAME="aws_list-accounts-$DEPLOY_ENV"
 aws lambda invoke \
 --function-name "$LAMBDA_NAME" \
 --payload '{}' \
 out.json > /dev/null 2>&1
 echo "✅ Lambda invoked correctly."
+echo "Waiting for 3 minutes..."
+sleep 180


### PR DESCRIPTION
This pr introduces a fix for the health check of the subdomain takeover monitoring tool on aws.
It also introduces the health check both for dev and prod env. 