### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -1,4 +1,6 @@
 
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/pagopa/subdomain-takeover-monitoring/security/code-scanning/6](https://github.com/pagopa/subdomain-takeover-monitoring/security/code-scanning/6)

The fix is to explicitly set a `permissions` block in the workflow or job definition to specify the least privilege required. Since the workflow steps only appear to need read access to repository contents (via `actions/checkout`), and do not interact with issues, pull requests, or other write operations, setting `contents: read` is appropriate. You can add this block either at the workflow root (to apply to all jobs), or under the `build` job. To minimize future mistakes, it's often best to set it at the top level.  
**Change required:**  
- In `.github/workflows/test-pipeline.yml`, add a `permissions:` block immediately after the `name:` (if present) or at the top, before `on:`.  
- The content should be:
  ```yaml
  permissions:
    contents: read
  ```
- No other imports, definitions, or code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
