### PR TITLE
Chore: removed azureedge from vulnerable resources

### DIFF
--- a/assets/img/queries/query_azure
+++ b/assets/img/queries/query_azure
@@ -46,7 +46,6 @@ resources
 (
 	dnsEndpoint endswith 'azure-api.net', 'azure-api.net',
 	dnsEndpoint endswith 'azurecontainer.io', 'azurecontainer.io',
-	dnsEndpoint endswith 'azureedge.net', 'azureedge.net',
 	dnsEndpoint endswith 'azurewebsites.net', 'azurewebsites.net',
 	dnsEndpoint endswith 'blob.core.windows.net', 'blob.core.windows.net', 
 	dnsEndpoint endswith 'cloudapp.azure.com', 'cloudapp.azure.com',

--- a/cmd/azure/azure.go
+++ b/cmd/azure/azure.go
@@ -153,13 +153,6 @@ func getDnsCNAMERecords(resources map[string]struct{}, dnsZone armdns.Zone, subs
 				continue
 			}
 
-			/*if strings.Contains(cname, "azureedge.net") {
-				splits := strings.Split(cname, ".")
-				if len(splits) >= 4 {
-					cname = strings.Join(splits[len(splits)-3:], ".")
-				}
-			}*/
-
 			if isVulnerableResource(resources, cname) {
 				vulnerableResources = append(vulnerableResources, fqdn+" -> "+cname)
 			}

--- a/cmd/azure/azure.go
+++ b/cmd/azure/azure.go
@@ -102,7 +102,6 @@ func containsAzureVulnerableResources(resource string) bool {
 	azureVulnerableDomains := []string{
 		"azure-api.net",
 		"azurecontainer.io",
-		"azureedge.net",
 		"azurewebsites.net",
 		"blob.core.windows.net",
 		"cloudapp.azure.com",
@@ -154,12 +153,12 @@ func getDnsCNAMERecords(resources map[string]struct{}, dnsZone armdns.Zone, subs
 				continue
 			}
 
-			if strings.Contains(cname, "azureedge.net") {
+			/*if strings.Contains(cname, "azureedge.net") {
 				splits := strings.Split(cname, ".")
 				if len(splits) >= 4 {
 					cname = strings.Join(splits[len(splits)-3:], ".")
 				}
-			}
+			}*/
 
 			if isVulnerableResource(resources, cname) {
 				vulnerableResources = append(vulnerableResources, fqdn+" -> "+cname)

--- a/cmd/azure/azure_test.go
+++ b/cmd/azure/azure_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -211,7 +210,7 @@ func writeTestFile(filename, content string) error {
 
 // Benchmark tests
 func BenchmarkContainsAzureVulnerableResources(b *testing.B) {
-	testResource := "myapp.azureedge.net"
+	testResource := "myapp.azurewebsites.net"
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -222,10 +221,9 @@ func BenchmarkContainsAzureVulnerableResources(b *testing.B) {
 func BenchmarkIsVulnerableResource(b *testing.B) {
 	resources := make(map[string]struct{})
 	for i := 0; i < 1000; i++ {
-		resources[fmt.Sprintf("resource%d.azureedge.net", i)] = struct{}{}
+		resources[fmt.Sprintf("resource%d.azurewebsites.net", i)] = struct{}{}
 	}
-	testCname := "test.azureedge.net"
-
+	testCname := "test.azurewebsites.net"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		isVulnerableResource(resources, testCname)
@@ -269,7 +267,7 @@ func TestAFDProfile(t *testing.T) {
 }
 
 // Test for edge cases in domain processing
-func TestDomainProcessingEdgeCases(t *testing.T) {
+/*func TestDomainProcessingEdgeCases(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -308,7 +306,7 @@ func TestDomainProcessingEdgeCases(t *testing.T) {
 			assert.Equal(t, tt.expected, cname)
 		})
 	}
-}
+}*/
 
 // Test constants
 func TestConstants(t *testing.T) {

--- a/cmd/azure/azure_test.go
+++ b/cmd/azure/azure_test.go
@@ -266,48 +266,6 @@ func TestAFDProfile(t *testing.T) {
 	}
 }
 
-// Test for edge cases in domain processing
-/*func TestDomainProcessingEdgeCases(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "azureedge.net with subdomain",
-			input:    "cdn-endpoint.azureedge.net",
-			expected: "cdn-endpoint.azureedge.net",
-		},
-		{
-			name:     "azureedge.net with multiple subdomains",
-			input:    "sub.cdn-endpoint.azureedge.net",
-			expected: "cdn-endpoint.azureedge.net", // Should extract last 3 parts
-		},
-		{
-			name:     "Regular domain",
-			input:    "example.com",
-			expected: "example.com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// This tests the logic that would be in getDnsCNAMERecords
-			// for processing azureedge.net domains
-			cname := strings.TrimRight(strings.TrimSpace(tt.input), ".")
-
-			if strings.Contains(cname, "azureedge.net") {
-				splits := strings.Split(cname, ".")
-				if len(splits) >= 4 {
-					cname = strings.Join(splits[len(splits)-3:], ".")
-				}
-			}
-
-			assert.Equal(t, tt.expected, cname)
-		})
-	}
-}*/
-
 // Test constants
 func TestConstants(t *testing.T) {
 	assert.Equal(t, "azure", AZURE_ORG)


### PR DESCRIPTION
The code has been updated to remove the Azure Edge service from the vulnerable service since is not subject to subdomain takeovers anymore, mitigated from Microsoft.

In cmd/azure/azure.go file, it has been removed the string “[azureedge.net](http://azureedge.net/)" from the vulnerable resources, in the func containsAzureVulnerableResources. Excluded the azureedge split logic.

In cmd/azure/azure_test.go it has been removed the string "[azureedge.net](http://azureedge.net/)" and replaced with the still vulnerable domain “azure[websites.net]. Excluded the function "func TestDomainProcessingEdgeCases"

In assets/img/queries/query_azure it has been removed the string ‘regarding azureedge.