### PR TITLE
fix: align test-pipeline go toolchain to go.mod

### DIFF
--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
       with:
-        go-version: '1.22.4'
+        go-version-file: 'go.mod'
     
     - name: 'Compute after coverage'
       shell: bash


### PR DESCRIPTION
Renovate PR #42 introduces a build failure caused by the mismatch between the pinned Go 1.22.4 in test-pipeline and the go 1.25 directive introduced by Renovate.

This PR replaces the pinned go-version: 1.22.4 with go-version-file: go.mod, so the CI always uses whatever Go version the module declares. This the references in setup-go action: [https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#using-the-go-version-file-input]

